### PR TITLE
chore(deps): add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,128 @@
+# Dependabot configuration file
+# See documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the root directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Set reviewers for pull requests
+    reviewers:
+      - "scaredfinger"
+    # Group all updates together
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    # Set the version requirement update strategy
+    versioning-strategy: increase
+    # Limit the number of open pull requests for npm dependencies
+    open-pull-requests-limit: 10
+    # Set the commit message prefix
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    # Labels for pull requests
+    labels:
+      - "dependencies"
+    
+  # Enable updates for individual packages in the monorepo
+  - package-ecosystem: "npm"
+    directory: "/libs/biz-builder"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "scaredfinger"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    versioning-strategy: increase
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/libs/utils/common"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "scaredfinger"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    versioning-strategy: increase
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/libs/utils/graphql"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "scaredfinger"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    versioning-strategy: increase
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/libs/utils/logging"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "scaredfinger"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    versioning-strategy: increase
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Look for `.github/workflows` files in the `/.github` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "scaredfinger"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "ci"
+      - "dependencies"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -25,28 +25,42 @@ Add the following records to your host file.
 ## Main steps
 
 For building the whole project. Needed before you run any of the apps
-
 ```bash
 pnpm nx run-many --target build --all
 ```
 
 For running omnidata
-
 ```bash
 pnpm nx dev omnidata
 ```
 
 For stopping it omnidata
-
 ```bash
 pnpm nx stop omnidata
 ```
 
 For cleanning all data
-
 ```bash
 pnpm nx clean omnidata
 ```
+
+## Dependency Management
+
+This project uses GitHub's Dependabot to keep dependencies up-to-date. Dependabot automatically creates pull requests for dependency updates on a weekly schedule (every Monday).
+
+### Dependabot Configuration
+
+- Root package.json and all library dependencies are monitored
+- Updates are grouped together to minimize PR noise
+- Minor and patch updates can be auto-merged
+- Configuration is in `.github/dependabot.yml`
+
+### Reviewing Dependency Updates
+
+When Dependabot creates a PR:
+1. CI will run to validate that the update doesn't break the build
+2. Minor and patch updates will auto-merge if tests pass
+3. Major updates require manual review and merge
 
 ## Sample data
 
@@ -63,13 +77,11 @@ Download `.secrets`, `.env.staging`, `.env` and copy to root directory.
 ```
 
 If you see errors, most of the times is due to permissions.
-
 ```bash
 ./fix-permissions.sh
 ```
 
 If you want to clean up
-
 ```bash
 ./clean-up.sh
 ```
@@ -118,7 +130,7 @@ The `_deps` folder. No better name yet, but the underscore ensures it's the firs
 
 ## Components structure
 
-There is always a top level components folder. There may be a optional category intermediate folder (e.g: buttons). Then there is the
+There is always a top level components folder. There may be a optional category intermediate folder (e.g: buttons). Then there is the 
 components or their folders. For simple components create a file, for components that have sub components, create folders.
 
 ```yaml


### PR DESCRIPTION
## Dependabot Integration

This PR adds Dependabot to automatically manage dependency updates in the project.

### Added
- GitHub Dependabot configuration (`.github/dependabot.yml`)
- Auto-merge workflow for minor and patch updates
- Documentation in README.md

### Configuration Details
- Weekly update schedule (every Monday)
- Configured for NPM packages and GitHub Actions
- Monitors root project and all libraries in the monorepo
- Groups dependency updates to minimize PR noise
- Auto-merges non-breaking updates (minor and patch versions)
- Uses conventional commit format for all updates

### How It Works
1. Every Monday, Dependabot will scan for outdated dependencies
2. It will create PRs for any updates, grouping them by package
3. CI will run to ensure the updates don't break anything
4. Minor and patch updates will auto-merge if CI passes
5. Major updates will require manual review

This setup follows package management best practices and will help keep dependencies secure and up-to-date without requiring manual intervention for most updates.